### PR TITLE
Remove extra port-forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ docker run \
     --rm \
     --name ggx-local-node \
     -u $(id -g):$(id -u) \
-    -p 9944:9944 \
-    -p 9933:9933 \
     -p 30333:30333 \
     -v $(pwd)/custom-spec-files:/tmp \
     -v $(pwd)/data-brooklyn:/data-brooklyn \
@@ -74,8 +72,6 @@ docker run \
     --rm \
     --name ggx-local-node \
     -u $(id -g):$(id -u) \
-    -p 9944:9944 \
-    -p 9933:9933 \
     -p 30333:30333 \
     -v $(pwd)/custom-spec-files:/tmp \
     -v $(pwd)/data-sydney:/data-sydney \


### PR DESCRIPTION
Port-forwarding `9933:9933` and `9944:9944` does not work because we don't run node with `--rpc-external` and `--ws-external`. So we can remove extra port-forwarding.