### PR TITLE
fix token decimals in mocked data and runtime data

### DIFF
--- a/node/src/runtime/testnet.rs
+++ b/node/src/runtime/testnet.rs
@@ -242,9 +242,9 @@ pub fn testnet_genesis(
 			],
 			metadata: vec![
 				// id, name, symbol, decimals
-				(999, "Bitcoin".into(), "BTC".into(), 10),
+				(999, "Bitcoin".into(), "BTC".into(), 8),
 				(888, "GGxchain".into(), "GGXT".into(), 18),
-				(777, "USDT".into(), "USDT".into(), 10),
+				(777, "USDT".into(), "USDT".into(), 6),
 				(666, "ERT".into(), "ERT".into(), 18),
 				(667, "Stake".into(), "STAKE".into(), 18),
 			],

--- a/pallet/dex/src/mock.rs
+++ b/pallet/dex/src/mock.rs
@@ -164,9 +164,9 @@ impl ExtBuilder {
 			],
 			metadata: vec![
 				// id, name, symbol, decimals
-				(999, "Bitcoin".into(), "BTC".into(), 10),
+				(999, "Bitcoin".into(), "BTC".into(), 8),
 				(888, "GGxchain".into(), "GGXT".into(), 18),
-				(777, "USDT".into(), "USDT".into(), 10),
+				(777, "USDT".into(), "USDT".into(), 6),
 			],
 			accounts: vec![
 				// id, account_id, balance


### PR DESCRIPTION
999 Bitcoin: decimals should be 8
777 USDT : decimals should be 6